### PR TITLE
add git requirement to the environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - pytest
   - mypy
   - pip
+  - git


### PR DESCRIPTION
This adds the `git` requirement to the environment.yml, as it is necessary during the `pip` install step

Background:
I tried to install `fibsem` on a machine where the only version of git was installed through `conda`, which means that the `pip` install inside the `fibsem` environment would error out by not having `git` available. Adding this line to the `environment.yml` solved the issue.

Feel free to close this PR if it is not wanted/needed