### PR TITLE
Fix autolamella example

### DIFF
--- a/example/autolamella.py
+++ b/example/autolamella.py
@@ -53,7 +53,7 @@ def main():
             # milling._draw_fiducial_patterns(microscope, MillingSettings.__from_dict__(settings.protocol["fiducial"]))
 
             # set filepaths
-            path = os.path.join(settings.image.save_path, lamella_no)
+            path = os.path.join(settings.image.save_path, str(lamella_no))
             settings.image.save_path = path
             
             lamella = Lamella(
@@ -79,7 +79,7 @@ def main():
         logging.info(f"Starting milling stage {stage_no}")
 
         lamella: Lamella
-        for lamella_no, lamella in sample:
+        for lamella_no, lamella in enumerate(sample):
 
             logging.info(f"Starting lamella {lamella_no}")
 

--- a/example/protocol_autolamella.yaml
+++ b/example/protocol_autolamella.yaml
@@ -17,6 +17,7 @@ lamella:
     offset: 5.e-6
     size_ratio: 1.0
     milling_current: 2.e-9
+    cleaning_cross_section: False
   - lamella_width: 10.e-6
     lamella_height: 5.e-6
     trench_height: 2.e-6
@@ -24,3 +25,4 @@ lamella:
     offset: 0.e-6
     size_ratio: 1.0
     milling_current: 2.e-9
+    cleaning_cross_section: False

--- a/fibsem/alignment.py
+++ b/fibsem/alignment.py
@@ -102,7 +102,7 @@ def beam_shift_alignment(
     microscope: SdbMicroscopeClient,
     image_settings: ImageSettings,
     ref_image: AdornedImage,
-    reduced_area: Rectangle,
+    reduced_area: Rectangle = None,
 ):
     """Align the images by adjusting the beam shift, instead of moving the stage
             (increased precision, lower range)

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -378,15 +378,19 @@ def log_current_figure(fig, name: str):
     import matplotlib.pyplot as plt
     import datetime
     import os
-    from liftout.config import config
+    try:
+        from liftout.config import config
+        log_data_path = config.LOG_DATA_PATH
+    except ModuleNotFoundError:
+        log_data_path = './'
 
     now = datetime.datetime.now()
     timestamp = now.strftime("%Y-%m-%d_%H-%M-%S")
     day = now.strftime("%Y-%m-%d")
-    os.makedirs(os.path.join(config.LOG_DATA_PATH, day), exist_ok=True)
+    os.makedirs(os.path.join(log_data_path, day), exist_ok=True)
 
     try:
-        plt.savefig(os.path.join(config.LOG_DATA_PATH, day, f"{name}_{timestamp}.png"))
+        plt.savefig(os.path.join(log_data_path, day, f"{name}_{timestamp}.png"))
         plt.close(fig)
     except Exception as e:
         print(f"Error: {e}")


### PR DESCRIPTION
I tried to run the the autolamella example today and ran into several issues, feel free to merge individual commits if you don't agree with my solution for any of the others:
- 321dd4c93ef473701a91631df5dc7a32cebcbcb3 solves two issues with the examples/autolamella.py, namely that `os.path.join` expects `str` or `bytes` not `int` and that `sample` can't be unpacked (looking at the rest of the code I assumed an `enumerate` was missing here.
- cb26082cd386bc7a4a65c6401a861d19e6d2f9e3 deals with the fact that the script does not give the required positional argument `reduced_area` to `beam_shift_alignment`. Looking at the code it is only used for `acquire.new_image(microscope, settings=image_settings, reduced_area=reduced_area)`, where `None` is an acceptable default, so I also added that as a default to this function.
- 220507a93052eac310c5ee2953b9bc33dda5eb84 deals with the fact that the `log_current_figure` requires the (optional) package `liftout`. This was not installed on the machine I ran, so I rewrote the code so `liftout` is not required for that function.
- 7293f357fb7536ccbcf3035a355dba3f4e8495f3 `cleaning_cross_section` is now a required keyword for a milling protocol so I added it to `example/protocol_autolamella.yaml`