### PR TITLE
Various RFI changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,15 +56,25 @@ fibsem
 #### Milling Strategy
 -  Previously, openfibsem only supported a basic milling process; Set milling settings, draw patterns, mill patterns, restore imaging settings. Milling strategies enable customising the milling process. 
 - Currently only Standard and Overtilt milling are implemented, but more will be added in the future.
-- Developers can add additional strategies by implementing the spec in milling.base, and register them using a plugin-style registry:
+- Developers can add additional strategies by implementing the spec in milling.base. Additional strategies can be registered by:
+  - Registering them using a plugin-style registry
+    ```
+    from fibsem.milling.strategy import register_strategy
+    from custom_strategy import CustomMillingStrategy
 
-```
-from fibsem.milling.strategy import register_strategy
-from custom_strategy import CustomMillingStrategy
+    register_strategy(CustomMillingStrategy)
 
-register_strategy(CustomMillingStrategy)
+    ```
+  - Creating a `fibsem.strategies` entrypoint that points to the strategy class and installing the package in the same environment as fibsem, e.g. in pyproject.toml:
+    ```
+    [project.entry-points.'fibsem.strategies']
 
-```
+    # Make the strategy discoverable by fibsem
+    # The class CustomMillingStrategy is in my_pkg/strategy.py
+
+    strategy = "my_pkg.strategy:CustomMillingStrategy"
+
+    ```
 
 #### Milling Alignment
 - Previously, aligning milling currents was only available via the autolamella option (align_at_milling_current). This was not straightforward to use or easily discoverable. 

--- a/fibsem/conversions.py
+++ b/fibsem/conversions.py
@@ -6,7 +6,7 @@ from fibsem.structures import FibsemImage, Point
 
 
 def image_to_microscope_image_coordinates(
-    coord: Point, image: np.ndarray, pixelsize: float
+    coord: Point, image: np.ndarray, pixelsize: float, subpixel_precision: bool = False
 ) -> Point:
     """
     Convert an image pixel coordinate to a microscope image coordinate.
@@ -17,6 +17,7 @@ def image_to_microscope_image_coordinates(
         coord (Point): A Point object representing the pixel coordinates in the original image.
         image (np.ndarray): A numpy array representing the image.
         pixelsize (float): The pixel size in meters.
+        subpixel_precision (bool): Rounds to the nearest pixel if False (default)
 
     Returns:
         Point: A Point object representing the corresponding microscope image coordinates in meters.
@@ -24,7 +25,10 @@ def image_to_microscope_image_coordinates(
     # convert from image pixel coord (0, 0) top left to microscope image (0, 0) mid
 
     # shape
-    cy, cx = np.asarray(image.shape) // 2
+    centre_px = np.asarray(image.shape) / 2
+    if not subpixel_precision:
+        centre_px = np.round(centre_px).astype(np.int_)
+    cy, cx = centre_px
 
     # distance from centre?
     dy = float(-(coord.y - cy))  # neg = down

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from packaging.version import parse
 from psygnal import Signal
 
 THERMO_API_AVAILABLE = False
@@ -31,14 +30,14 @@ try:
     import autoscript_sdb_microscope_client
     from autoscript_sdb_microscope_client import SdbMicroscopeClient
     version = autoscript_sdb_microscope_client.build_information.INFO_VERSIONSHORT
-    VERSION = parse(version)
-    if VERSION < parse("4.6"):
+    VERSION = tuple(int(_) for _ in version.split(".")[:2])
+    if VERSION < (4, 6):
         raise NameError(
             f"AutoScript {version} found. Please update your AutoScript version to 4.6 or higher."
         )
 
     if _OVERWRITE_AUTOSCRIPT_VERSION:
-        VERSION = parse("4.7")
+        VERSION = (4, 7)
         
     from autoscript_sdb_microscope_client._dynamic_object_proxies import (
         CirclePattern,
@@ -1797,7 +1796,7 @@ class ThermoMicroscope(FibsemMicroscope):
          
         if name not in ["PARK", "EUCENTRIC"]:
             raise ValueError(f"insert position {name} not supported.")
-        if VERSION < 4.7:
+        if VERSION < (4, 7):
             raise NotImplementedError("Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher")
         
         # get the saved position name
@@ -1820,7 +1819,7 @@ class ThermoMicroscope(FibsemMicroscope):
     def retract_manipulator(self):
         """Retract the manipulator"""        
 
-        if VERSION < 4.7:
+        if VERSION < (4, 7):
             raise NotImplementedError("Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher")
 
         if not self.is_available("manipulator"):
@@ -1980,7 +1979,7 @@ class ThermoMicroscope(FibsemMicroscope):
         
         if name not in ["PARK", "EUCENTRIC"]:
             raise ValueError(f"saved position {name} not supported.")
-        if VERSION < 4.7:
+        if VERSION < (4, 7):
             raise NotImplementedError("Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher")
         
         named_position = ManipulatorSavedPosition.PARK if name == "PARK" else ManipulatorSavedPosition.EUCENTRIC

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1,3 +1,4 @@
+import re
 import copy
 import datetime
 import logging
@@ -30,7 +31,13 @@ try:
     import autoscript_sdb_microscope_client
     from autoscript_sdb_microscope_client import SdbMicroscopeClient
     version = autoscript_sdb_microscope_client.build_information.INFO_VERSIONSHORT
-    VERSION = tuple(int(_) for _ in version.split(".")[:2])
+    try:
+        m = re.match(r"^(\d+)\.(\d+)", version)
+        if m is None:
+            raise TypeError("No regex match found")
+        VERSION = (int(m.group(1)), int(m.group(2)))
+    except Exception as e:
+        raise NameError(f"Failed to parse AutoScript version '{version}': {e}")
     if VERSION < (4, 6):
         raise NameError(
             f"AutoScript {version} found. Please update your AutoScript version to 4.6 or higher."

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -24,10 +24,10 @@ if os.environ.get("COMPUTERNAME", "hostname") == "MU00190108":
     print("Overwriting autoscript version to 4.7, for Monash dev install")
 
 try:
-    sys.path.append('C:\Program Files\Thermo Scientific AutoScript')
-    sys.path.append('C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages')
-    sys.path.append('C:\Program Files\Python36\envs\AutoScript')
-    sys.path.append('C:\Program Files\Python36\envs\AutoScript\Lib\site-packages')
+    sys.path.append(r'C:\Program Files\Thermo Scientific AutoScript')
+    sys.path.append(r'C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages')
+    sys.path.append(r'C:\Program Files\Python36\envs\AutoScript')
+    sys.path.append(r'C:\Program Files\Python36\envs\AutoScript\Lib\site-packages')
     import autoscript_sdb_microscope_client
     from autoscript_sdb_microscope_client import SdbMicroscopeClient
     version = autoscript_sdb_microscope_client.build_information.INFO_VERSIONSHORT

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -80,11 +80,14 @@ try:
         Limits,
         Limits2d
     )
-    THERMO_API_AVAILABLE = True 
-except Exception as e:
-    logging.debug("Autoscript (ThermoFisher) not installed.")
-    if isinstance(e, AutoScriptException):
-        raise e 
+    THERMO_API_AVAILABLE = True
+except AutoScriptException as e:
+    logging.warning("Failed to load AutoScript (ThermoFisher): %s", str(e))
+    raise
+except Exception:
+    logging.error("Failed to load AutoScript (ThermoFisher) due to unexpected error", exc_info=True)
+    raise
+
 
 import fibsem.constants as constants
 from fibsem.structures import (

--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -51,9 +51,14 @@ class MillingStrategy(ABC):
     def run(self, microscope: FibsemMicroscope, stage: "FibsemMillingStage", asynch: bool = False, parent_ui = None) -> None:
         pass
 
-def get_strategy(name: str = "Standard", config: Dict[str, Any] = {}) -> MillingStrategy:
-    from fibsem.milling.strategy import strategies, StandardMillingStrategy
-    return strategies.get(name, StandardMillingStrategy).from_dict(config)
+
+def get_strategy(
+    name: str = "Standard", config: Dict[str, Any] = {}
+) -> MillingStrategy:
+    from fibsem.milling.strategy import get_strategies, DEFAULT_STRATEGY
+
+    strategies = get_strategies()
+    return strategies.get(name, DEFAULT_STRATEGY).from_dict(config)
 
 
 @dataclass

--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, fields
-from typing import List, Union, Dict, Any, Tuple
+from typing import List, Union, Dict, Any, Tuple, Optional
 
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.config import MILLING_SPUTTER_RATE
@@ -53,9 +53,12 @@ class MillingStrategy(ABC):
 
 
 def get_strategy(
-    name: str = "Standard", config: Dict[str, Any] = {}
+    name: str = "Standard", config: Optional[Dict[str, Any]] = None
 ) -> MillingStrategy:
     from fibsem.milling.strategy import get_strategies, DEFAULT_STRATEGY
+
+    if config is None:
+        config = {}
 
     strategies = get_strategies()
     return strategies.get(name, DEFAULT_STRATEGY).from_dict(config)

--- a/fibsem/milling/strategy/__init__.py
+++ b/fibsem/milling/strategy/__init__.py
@@ -1,15 +1,60 @@
-from typing import Dict
+import logging
+import typing
+from functools import cache
+
 from fibsem.milling.base import MillingStrategy
 from fibsem.milling.strategy.standard import StandardMillingStrategy
 from fibsem.milling.strategy.overtilt import OvertiltTrenchMillingStrategy
 
-DEFAULT_STRATEGY = StandardMillingStrategy.name
-strategies: Dict[str, MillingStrategy] = {
+
+DEFAULT_STRATEGY = StandardMillingStrategy
+DEFAULT_STRATEGY_NAME = DEFAULT_STRATEGY.name
+BUILTIN_STRATEGIES: typing.Dict[str, type[MillingStrategy]] = {
     StandardMillingStrategy.name: StandardMillingStrategy,
     OvertiltTrenchMillingStrategy.name: OvertiltTrenchMillingStrategy,
 }
-MILLING_STRATEGY_NAMES = list(strategies.keys())
 
-def register_strategy(strategy_cls: MillingStrategy):
-    strategies[strategy_cls.name] = strategy_cls
-    MILLING_STRATEGY_NAMES.append(strategy_cls.name)
+
+@cache
+def get_strategies() -> typing.Dict[str, type[MillingStrategy]]:
+    strategies = BUILTIN_STRATEGIES.copy()
+    for strategy in _get_additional_strategies():
+        strategies[strategy.name] = strategy
+    return strategies
+
+
+def get_strategy_names() -> typing.List[str]:
+    return list(get_strategies().keys())
+
+
+def _get_additional_strategies() -> typing.Generator[type[MillingStrategy], None, None]:
+    """
+    Import new strategies and append them to the list here
+
+    The plugin logic is based on:
+    https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata
+    """
+    import sys
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import entry_points
+    else:
+        from importlib.metadata import entry_points
+
+    for strategy_entry_point in entry_points(group="fibsem.strategies"):
+        try:
+            strategy = strategy_entry_point.load()
+            if not issubclass(strategy, MillingStrategy):
+                raise TypeError(
+                    f"'{strategy_entry_point.value}' is not a subclass of MillingStrategy"
+                )
+            logging.info("Loaded strategy '%s'", strategy.name)
+            yield strategy
+        except TypeError as e:
+            logging.warning("Invalid strategy found: %s", str(e))
+        except Exception:
+            logging.error(
+                "Unexpected error raised while attempting to import strategy from '%s'",
+                strategy_entry_point.value,
+                exc_info=True,
+            )

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -18,12 +18,12 @@ from fibsem.config import METADATA_VERSION, SUPPORTED_COORDINATE_SYSTEMS
 from abc import ABC, abstractmethod
 
 try:
-    sys.path.append("C:\Program Files\Thermo Scientific AutoScript")
+    sys.path.append(r"C:\Program Files\Thermo Scientific AutoScript")
     sys.path.append(
-        "C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages"
+        r"C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages"
     )
-    sys.path.append("C:\Program Files\Python36\envs\AutoScript")
-    sys.path.append("C:\Program Files\Python36\envs\AutoScript\Lib\site-packages")
+    sys.path.append(r"C:\Program Files\Python36\envs\AutoScript")
+    sys.path.append(r"C:\Program Files\Python36\envs\AutoScript\Lib\site-packages")
     from autoscript_sdb_microscope_client.enumerations import CoordinateSystem
     from autoscript_sdb_microscope_client.structures import (
         AdornedImage,

--- a/fibsem/ui/FibsemMillingWidget.py
+++ b/fibsem/ui/FibsemMillingWidget.py
@@ -38,7 +38,7 @@ from fibsem.milling.patterning.patterns2 import (
     LinePattern,
     get_pattern,
 )
-from fibsem.milling.strategy import DEFAULT_STRATEGY, MILLING_STRATEGY_NAMES
+from fibsem.milling.strategy import DEFAULT_STRATEGY_NAME, get_strategy_names
 from fibsem.structures import (
     BeamType,
     CrossSectionPattern,
@@ -246,8 +246,8 @@ class FibsemMillingWidget(FibsemMillingWidgetUI.Ui_Form, QtWidgets.QWidget):
         self.comboBox_patterns.currentIndexChanged.connect(self.update_current_selected_pattern)
 
         # strategy
-        self.comboBox_strategy_name.addItems(MILLING_STRATEGY_NAMES)
-        self.comboBox_strategy_name.setCurrentText(DEFAULT_STRATEGY)
+        self.comboBox_strategy_name.addItems(get_strategy_names())
+        self.comboBox_strategy_name.setCurrentText(DEFAULT_STRATEGY_NAME)
         self.comboBox_strategy_name.currentIndexChanged.connect(self.update_current_selected_strategy) # TODO: connect event
         # TODO: auto-update drift correction and strategy on value changes
 
@@ -357,7 +357,7 @@ class FibsemMillingWidget(FibsemMillingWidgetUI.Ui_Form, QtWidgets.QWidget):
         num = len(self.milling_stages) + 1
         name = f"Milling Stage {num}"
         pattern = get_default_milling_pattern(DEFAULT_MILLING_PATTERN)
-        strategy = get_strategy(DEFAULT_STRATEGY)
+        strategy = get_strategy(DEFAULT_STRATEGY_NAME)
         milling_stage = FibsemMillingStage(name=name, 
                                            num=num, 
                                            pattern=pattern, 

--- a/scripts/test_installation.py
+++ b/scripts/test_installation.py
@@ -1,4 +1,4 @@
-from fibsem.microscope import _THERMO_API_AVAILABLE
+from fibsem.microscope import THERMO_API_AVAILABLE
 from fibsem.microscopes.tescan import TESCAN_API_AVAILABLE
 
 def main():
@@ -40,8 +40,8 @@ def main():
     print(f"Hardware APIs:\n")
     
     # Thermo Fisher API
-    print(f"ThermoFisher API {'Available' if _THERMO_API_AVAILABLE else 'Not Available'}")
-    if _THERMO_API_AVAILABLE:
+    print(f"ThermoFisher API {'Available' if THERMO_API_AVAILABLE else 'Not Available'}")
+    if THERMO_API_AVAILABLE:
         from fibsem.microscope import version as autoscript_version
         print(f"AutoScript v{autoscript_version}")
     print(f"-" * 80)


### PR DESCRIPTION
Hi Patrick,

I've updated some things based on your email and I'll include the bitmap stuff in a separate PR because it's a bit more fiddly.

 Changes:
1. Raw strings for the Autoscript paths added to sys.path to avoid unwanted escapes.
2. Allow subpixel precision in `image_to_microscope_image_coordinates`. This is because I'm we are using a mask that was created from a downsized image to determine the lamella centre, but I don't want to lose precision due to this. I'm not really sure why it was limited by resolution, so I didn't want to change the default behaviour without understanding this and have set the argument default as `subpixel_precision: bool = False`.
3. I realised that a simpler way to do the Autoscript version parsing was to just use tuples of ints, so I've done that instead.
4. The entrypoint-based strategy registering. I haven't changed this since I sent you the email and an example of how it's used can be found [here](https://github.com/rosalindfranklininstitute/adaptive_polish/tree/rfi-upstream-merge) - I believe you have access but let me know if you have any issues.
5. There is a script that has `_THERMO_API_AVAILABLE` in it, so I've changed them to use `THERMO_API_AVAILABLE` to fix the import (that's why I looked to change to `_THERMO_API_AVAILABLE` before).

Thanks,
Tom