### PR TITLE
Update inheritance for patterns and strategies

### DIFF
--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -5,8 +5,7 @@ from typing import Dict, List, Tuple, Union, Any, Optional, Type, ClassVar, Type
 
 import numpy as np
 
-from fibsem import config as cfg
-from fibsem import constants, utils
+from fibsem import constants
 from fibsem.structures import (
     CrossSectionPattern,
     FibsemBitmapSettings,
@@ -1075,14 +1074,14 @@ PROTOCOL_MILL_MAP = {
     "mill_polishing": TrenchPattern,
 }
 
-def get_pattern(name: str, config: dict) -> BasePattern:
-    cls_pattern = MILLING_PATTERNS.get(name.lower())
+def get_pattern(name: str, config: Optional[Dict[str, Any]] = None) -> BasePattern:
+    if config is None:
+        config = {}
+
+    name = name.lower()
+    if name not in MILLING_PATTERNS:
+        raise NameError("No milling pattern named '%s'")
+
+    cls_pattern = MILLING_PATTERNS[name]
     pattern = cls_pattern.from_dict(config)
     return pattern
-
-# default milling protocol
-DEFAULT_PROTOCOL = utils.load_yaml(cfg.PROTOCOL_PATH)
-
-def get_default_milling_pattern(name: str) -> BasePattern:
-    """Get the default milling pattern."""
-    return get_pattern(name, config = DEFAULT_PROTOCOL["patterns"][name])

--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -1039,7 +1039,7 @@ MILLING_PATTERNS: Dict[str, BasePattern] = {
     # BitmapPattern.name.lower(): BitmapPattern,
 }
 MILLING_PATTERN_NAMES = [p.name for p in MILLING_PATTERNS.values()]
-DEFAULT_MILLING_PATTERN = RectanglePattern.name
+DEFAULT_MILLING_PATTERN = RectanglePattern
 
 # legacy mapping
 PROTOCOL_MILL_MAP = {

--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -1020,7 +1020,7 @@ def create_triangle_patterns(
     return [left_pattern, right_pattern, bottom_pattern]
 
 
-MILLING_PATTERNS: Dict[str, BasePattern] = {
+MILLING_PATTERNS: Dict[str, Type[BasePattern]] = {
     RectanglePattern.name.lower(): RectanglePattern,
     LinePattern.name.lower(): LinePattern,
     CirclePattern.name.lower(): CirclePattern,

--- a/fibsem/milling/strategy/__init__.py
+++ b/fibsem/milling/strategy/__init__.py
@@ -9,14 +9,14 @@ from fibsem.milling.strategy.overtilt import OvertiltTrenchMillingStrategy
 
 DEFAULT_STRATEGY = StandardMillingStrategy
 DEFAULT_STRATEGY_NAME = DEFAULT_STRATEGY.name
-BUILTIN_STRATEGIES: typing.Dict[str, type[MillingStrategy]] = {
+BUILTIN_STRATEGIES: typing.Dict[str, type[MillingStrategy[typing.Any]]] = {
     StandardMillingStrategy.name: StandardMillingStrategy,
     OvertiltTrenchMillingStrategy.name: OvertiltTrenchMillingStrategy,
 }
-REGISTERED_STRATEGIES: typing.Dict[str, type[MillingStrategy]] = {}
+REGISTERED_STRATEGIES: typing.Dict[str, type[MillingStrategy[typing.Any]]] = {}
 
 
-def get_strategies() -> typing.Dict[str, type[MillingStrategy]]:
+def get_strategies() -> typing.Dict[str, type[MillingStrategy[typing.Any]]]:
     # This order means that builtins > registered > plugins if there are any name clashes
     return {**_get_plugin_strategies(), **REGISTERED_STRATEGIES, **BUILTIN_STRATEGIES}
 
@@ -25,13 +25,13 @@ def get_strategy_names() -> typing.List[str]:
     return list(get_strategies().keys())
 
 
-def register_strategy(strategy_cls: type[MillingStrategy]) -> None:
+def register_strategy(strategy_cls: type[MillingStrategy[typing.Any]]) -> None:
     global REGISTERED_STRATEGIES
     REGISTERED_STRATEGIES[strategy_cls.name] = strategy_cls
 
 
 @cache
-def _get_plugin_strategies() -> typing.Dict[str, type[MillingStrategy]]:
+def _get_plugin_strategies() -> typing.Dict[str, type[MillingStrategy[typing.Any]]]:
     """
     Import new strategies and append them to the list here
 
@@ -45,7 +45,7 @@ def _get_plugin_strategies() -> typing.Dict[str, type[MillingStrategy]]:
     else:
         from importlib.metadata import entry_points
 
-    strategies: typing.Dict[str, type[MillingStrategy]] = {}
+    strategies: typing.Dict[str, type[MillingStrategy[typing.Any]]] = {}
     for strategy_entry_point in entry_points(group="fibsem.strategies"):
         try:
             strategy = strategy_entry_point.load()

--- a/fibsem/milling/strategy/overtilt.py
+++ b/fibsem/milling/strategy/overtilt.py
@@ -1,7 +1,7 @@
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Tuple, List
 import numpy as np
 
@@ -18,36 +18,14 @@ from fibsem.structures import (BeamType, FibsemImage, FibsemRectangle,
 @dataclass
 class OvertiltTrenchMillingConfig(MillingStrategyConfig):
     overtilt: float = 1
-    resolution: List[int] = None
+    resolution: List[int] = field(default_factory=lambda: [1536, 1024])
 
-    def __post_init__(self):
-        if self.resolution is None:
-            self.resolution = [1536, 1024]
 
-    @staticmethod
-    def from_dict(d: dict) -> "OvertiltTrenchMillingConfig":
-        return OvertiltTrenchMillingConfig(**d)
-
-    def to_dict(self):
-        return {"overtilt": self.overtilt, }
-
-@dataclass
-class OvertiltTrenchMillingStrategy(MillingStrategy):
+class OvertiltTrenchMillingStrategy(MillingStrategy[OvertiltTrenchMillingConfig]):
     """Overtilt milling strategy for trench milling"""
     name: str = "Overtilt"
     fullname: str = "Overtilt Trench Milling"
-
-    def __init__(self, config: OvertiltTrenchMillingConfig = None):
-        self.config = config or OvertiltTrenchMillingConfig()
-
-    def to_dict(self):
-        return {"name": self.name, "config": self.config.to_dict()}
-
-    @staticmethod
-    def from_dict(d: dict) -> "OvertiltTrenchMillingStrategy":
-        config = OvertiltTrenchMillingConfig.from_dict(d["config"])
-        
-        return OvertiltTrenchMillingStrategy(config=config)
+    config_class = OvertiltTrenchMillingConfig
 
     def run(self, microscope: FibsemMicroscope, stage: "FibsemMillingStage", asynch: bool = False,
         parent_ui = None) -> None:

--- a/fibsem/milling/strategy/standard.py
+++ b/fibsem/milling/strategy/standard.py
@@ -15,22 +15,11 @@ class StandardMillingConfig(MillingStrategyConfig):
     pass
 
 
-@dataclass
-class StandardMillingStrategy(MillingStrategy):
+class StandardMillingStrategy(MillingStrategy[StandardMillingConfig]):
     """Basic milling strategy that mills continuously until completion"""
     name: str = "Standard"
     fullname: str = "Standard Milling"
-
-    def __init__(self, config: StandardMillingConfig = None):
-        self.config = config or StandardMillingConfig()
-
-    def to_dict(self):
-        return {"name": self.name, "config": self.config.to_dict()}
-
-    @staticmethod
-    def from_dict(d: dict) -> "StandardMillingStrategy":
-        config=StandardMillingConfig.from_dict(d.get("config", {}))   
-        return StandardMillingStrategy(config=config)
+    config_class = StandardMillingConfig
 
     def run(
         self,

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -4,11 +4,11 @@ import json
 import os
 import sys
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, asdict
 from datetime import datetime
 from enum import Enum, auto
 from pathlib import Path
-from typing import List, Optional, Tuple, Union, Set, Any, Dict
+from typing import List, Optional, Tuple, Union, Set, Any, Dict, Type, TypeVar
 
 import numpy as np
 import tifffile as tff
@@ -34,6 +34,10 @@ try:
     THERMO = True
 except ImportError:
     THERMO = False
+
+TFibsemPatternSettings = TypeVar(
+    "TFibsemPatternSettings", bound="FibsemPatternSettings"
+)
 
 @dataclass
 class Point:
@@ -863,14 +867,26 @@ class MicroscopeState:
 ########### Base Pattern Settings
 @dataclass
 class FibsemPatternSettings(ABC):
+    def to_dict(self) -> Dict[str, Any]:
+        ddict = asdict(self)
+        # Handle any special cases
+        if "cross_section" in ddict:
+            ddict["cross_section"] = ddict["cross_section"].name
+        return ddict
 
-    @abstractmethod
-    def to_dict(self) -> dict:
-        pass
-    
-    @staticmethod
-    def from_dict(self, data: dict) -> "FibsemPatternSettings":
-        pass
+    @classmethod
+    def from_dict(cls: Type[TFibsemPatternSettings], data: Dict[str, Any]) -> TFibsemPatternSettings:
+        kwargs = {}
+        for f in fields(cls):
+            if f.name in data:
+                # Handle any special cases
+                if f.name == "cross_section":
+                    value = CrossSectionPattern[data.get("cross_section", "Rectangle")]
+                else:
+                    value = data[f.name]
+                kwargs[f.name] = value
+
+        return cls(**kwargs)
 
     @property
     @abstractmethod
@@ -897,37 +913,6 @@ class FibsemRectangleSettings(FibsemPatternSettings):
     time: float = 0.0
     is_exclusion: bool = False
 
-    def to_dict(self) -> dict:
-        return {
-            "width": self.width,
-            "height": self.height,
-            "depth": self.depth,
-            "rotation": self.rotation,
-            "centre_x": self.centre_x,
-            "centre_y": self.centre_y,
-            "scan_direction": self.scan_direction,
-            "cross_section": self.cross_section.name,
-            "passes": self.passes,
-            "time": self.time,
-            "is_exclusion": self.is_exclusion,
-        }
-
-    @staticmethod
-    def from_dict(data: dict) -> "FibsemRectangleSettings":
-        return FibsemRectangleSettings(
-            width=data["width"],
-            height=data["height"],
-            depth=data["depth"],
-            centre_x=data["centre_x"],
-            centre_y=data["centre_y"],
-            rotation=data.get("rotation", 0),
-            scan_direction=data.get("scan_direction", "TopToBottom"),
-            cross_section=CrossSectionPattern[data.get("cross_section", "Rectangle")],
-            passes=data.get("passes", 0),
-            time=data.get("time", 0.0),
-            is_exclusion=data.get("is_exclusion", False),
-        )
-
     @property
     def volume(self) -> float:
         return self.width * self.height * self.depth
@@ -940,24 +925,6 @@ class FibsemLineSettings(FibsemPatternSettings):
     end_y: float
     depth: float
 
-    def to_dict(self) -> dict:
-        return {
-            "start_x": self.start_x,
-            "end_x": self.end_x,
-            "start_y": self.start_y,
-            "end_y": self.end_y,
-            "depth": self.depth,
-        }
-
-    @staticmethod
-    def from_dict(data: dict) -> "FibsemLineSettings":
-        return FibsemLineSettings(
-            start_x=data["start_x"],
-            end_x=data["end_x"],
-            start_y=data["start_y"],
-            end_y=data["end_y"],
-            depth=data["depth"],
-        )
     
     @property
     def volume(self) -> float:
@@ -975,33 +942,6 @@ class FibsemCircleSettings(FibsemPatternSettings):
     rotation: float = 0.0           # annulus -> thickness !=0
     is_exclusion: bool = False
 
-    def to_dict(self) -> dict:
-        return {
-            "radius": self.radius,
-            "depth": self.depth,
-            "centre_x": self.centre_x,
-            "centre_y": self.centre_y,
-            "start_angle": self.start_angle,
-            "end_angle": self.end_angle,
-            "rotation": self.rotation,
-            "thickness": self.thickness,
-            "is_exclusion": self.is_exclusion,
-        }
-
-    @staticmethod
-    def from_dict(data: dict) -> "FibsemCircleSettings":
-        return FibsemCircleSettings(
-            radius=data["radius"],
-            depth=data["depth"],
-            centre_x=data["centre_x"],
-            centre_y=data["centre_y"],
-            start_angle=data.get("start_angle", 0),
-            end_angle=data.get("end_angle", 360),
-            rotation=data.get("rotation", 0),
-            thickness=data.get("thickness", 0),
-            is_exclusion=data.get("is_exclusion", False),
-        )
-
     @property
     def volume(self) -> float:
         return np.pi * self.radius**2 * self.depth
@@ -1015,29 +955,6 @@ class FibsemBitmapSettings(FibsemPatternSettings):
     centre_x: float
     centre_y: float
     path: str = None
-
-    def to_dict(self) -> dict:
-        return {
-            "width": self.width,
-            "height": self.height,
-            "depth": self.depth,
-            "rotation": self.rotation,
-            "centre_x": self.centre_x,
-            "centre_y": self.centre_y,
-            "path": self.path,
-        }
-
-    @staticmethod
-    def from_dict(data: dict) -> "FibsemBitmapSettings":
-        return FibsemBitmapSettings(
-            width=data["width"],
-            height=data["height"],
-            depth=data["depth"],
-            rotation=data["rotation"],
-            centre_x=data["centre_x"],
-            centre_y=data["centre_y"],
-            path=data["path"],
-        )
 
     @property
     def volume(self) -> float:

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -879,12 +879,12 @@ class FibsemPatternSettings(ABC):
         kwargs = {}
         for f in fields(cls):
             if f.name in data:
-                # Handle any special cases
-                if f.name == "cross_section":
-                    value = CrossSectionPattern[data.get("cross_section", "Rectangle")]
-                else:
-                    value = data[f.name]
-                kwargs[f.name] = value
+                kwargs[f.name] = data[f.name]
+
+        # Construct objects
+        cross_section = kwargs.pop("cross_section", None)
+        if cross_section is not None:
+            kwargs["cross_section"] = CrossSectionPattern[cross_section]
 
         return cls(**kwargs)
 

--- a/fibsem/ui/FibsemMillingStageEditorWidget.py
+++ b/fibsem/ui/FibsemMillingStageEditorWidget.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Any
 
 import napari
 import napari.utils.notifications
@@ -544,7 +544,7 @@ class FibsemMillingStageWidget(QWidget):
         self._update_strategy_widget(strategy)
         self._milling_stage_changed.emit(self._milling_stage)  # Emit signal to notify changes
         
-    def _update_strategy_widget(self, strategy: MillingStrategy):
+    def _update_strategy_widget(self, strategy: MillingStrategy[Any]):
         """Update the strategy widget with the selected strategy's parameters."""
         params = {k: getattr(strategy.config, k) for k in strategy.config.required_attributes}
 

--- a/fibsem/ui/FibsemMillingStageEditorWidget.py
+++ b/fibsem/ui/FibsemMillingStageEditorWidget.py
@@ -40,6 +40,7 @@ from fibsem.milling.patterning.patterns2 import (
     BasePattern,
     LinePattern,
     TrenchPattern,
+    get_pattern,
 )
 from fibsem.milling.strategy import (
     MillingStrategy,
@@ -53,7 +54,7 @@ from fibsem.structures import (
     Point,
 )
 from fibsem.ui import stylesheets
-from fibsem.ui.FibsemMillingWidget import WheelBlocker, get_default_milling_pattern
+from fibsem.ui.FibsemMillingWidget import WheelBlocker
 from fibsem.ui.napari.patterns import (
     draw_milling_patterns_in_napari,
     is_pattern_placement_valid,
@@ -519,7 +520,7 @@ class FibsemMillingStageWidget(QWidget):
     def _on_pattern_changed(self, pattern_name: str):
         # TODO: convert the comboBox_selected_pattern to use currentData, 
         # that way we can pass the pattern object directly (and restore it from the previous state)
-        pattern = get_default_milling_pattern(pattern_name)
+        pattern = get_pattern(pattern_name)
 
         self._milling_stage.pattern = pattern  # Update the milling stage's strategy
 

--- a/fibsem/ui/FibsemMillingWidget.py
+++ b/fibsem/ui/FibsemMillingWidget.py
@@ -36,7 +36,7 @@ from fibsem.milling.patterning.patterns2 import (
     BasePattern,
     FiducialPattern,
     LinePattern,
-    get_default_milling_pattern,
+    get_pattern,
 )
 from fibsem.milling.strategy import DEFAULT_STRATEGY_NAME, get_strategy_names
 from fibsem.structures import (
@@ -356,7 +356,7 @@ class FibsemMillingWidget(FibsemMillingWidgetUI.Ui_Form, QtWidgets.QWidget):
 
         num = len(self.milling_stages) + 1
         name = f"Milling Stage {num}"
-        pattern = get_default_milling_pattern(DEFAULT_MILLING_PATTERN)
+        pattern = DEFAULT_MILLING_PATTERN()
         strategy = get_strategy(DEFAULT_STRATEGY_NAME)
         milling_stage = FibsemMillingStage(name=name, 
                                            num=num, 
@@ -658,7 +658,7 @@ class FibsemMillingWidget(FibsemMillingWidgetUI.Ui_Form, QtWidgets.QWidget):
         pattern_name = self.comboBox_patterns.currentText()
 
         logging.info(f"selected pattern: {pattern_name}")
-        pattern = get_default_milling_pattern(pattern_name)
+        pattern = get_pattern(pattern_name)
         self.current_milling_stage.pattern = pattern
         self.set_pattern_settings_ui()
 

--- a/tests/milling/test_patterns.py
+++ b/tests/milling/test_patterns.py
@@ -1,10 +1,11 @@
-from copy import deepcopy
+from __future__ import annotations
+from dataclasses import fields
 
 import numpy as np
 import pytest
 
 from fibsem.milling.patterning.patterns2 import (
-    DEFAULT_POINT_DDICT,
+    BasePattern,
     CirclePattern,
     FibsemCircleSettings,
     FibsemLineSettings,
@@ -21,6 +22,22 @@ from fibsem.milling.patterning.patterns2 import (
 from fibsem.structures import (
     CrossSectionPattern,
     Point,
+)
+
+@pytest.mark.parametrize("pattern", list(MILLING_PATTERNS.values()))
+def test_required_attributes(pattern: type[BasePattern]) -> None:
+    # test that core attributes are not inherited by required attributes for specific patterns
+    p = pattern()
+    assert "point" not in p.required_attributes
+    assert "shapes" not in p.required_attributes
+    assert "name" not in p.required_attributes
+
+    for f in fields(p):
+        if f.name in ["point", "shapes", "name"]:
+            continue
+        # check that all fields are in required attributes
+        assert f.name in p.required_attributes, (
+            f"{f.name} not in required attributes for {p.name}"
 )
 
 

--- a/tests/milling/test_patterns.py
+++ b/tests/milling/test_patterns.py
@@ -727,7 +727,7 @@ class TestFiducialPattern:
         assert fiducial.width == 10.0
         assert fiducial.height == 20.0
         assert fiducial.depth == 5.0
-        assert fiducial.rotation == 0
+        assert fiducial.rotation == 45
         assert fiducial.cross_section == CrossSectionPattern.Rectangle
         assert fiducial.name == "Fiducial"
         assert fiducial.point.x == 0.0


### PR DESCRIPTION
Hi Patrick,

Here are the pattern and strategy changes that simplify inheritance (especially for typing). There are a few things I wanted to query:
- `CirclePattern.thickness` defaults to 0 and has nothing set in the config. I have left it as 0.
- `FiducialPattern.rotation` defaults to 0 but was 45 in the config. I've changed it to 45, as that seems to be how it is used.
- `ArrayPattern.passes` defaults to 0, which other patterns say 'means auto', but it has a value of 1 in the config you sent. I have changed it to 0 since that is more consistent with the others.
- "passes" is in _advanced_attributes for `RectanglePattern` but not `ArrayPattern`. I have not changed this but I was wondering whether these should be consistent.

Please let me know what you think.