### PR TITLE
Integrate FibsemMillingStage.reference_image attribute

### DIFF
--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -6,7 +6,14 @@ from typing import List, Union, Dict, Any, Tuple, Optional, Type, TypeVar, Class
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.config import MILLING_SPUTTER_RATE
 from fibsem.milling.patterning.patterns2 import BasePattern, get_pattern, DEFAULT_MILLING_PATTERN
-from fibsem.structures import FibsemMillingSettings, Point, MillingAlignment, ImageSettings, CrossSectionPattern
+from fibsem.structures import (
+    FibsemMillingSettings,
+    MillingAlignment,
+    ImageSettings,
+    CrossSectionPattern,
+    FibsemImage,
+    FibsemImageMetadata,
+)
 
 
 TMillingStrategyConfig = TypeVar(
@@ -82,6 +89,7 @@ class FibsemMillingStage:
     strategy: MillingStrategy[Any] = field(default_factory=get_strategy)
     alignment: MillingAlignment = field(default_factory=MillingAlignment)
     imaging: ImageSettings = field(default_factory=ImageSettings) # settings for post-milling acquisition
+    reference_image: Optional[FibsemImage] = None
 
     def __post_init__(self):
         
@@ -104,7 +112,7 @@ class FibsemMillingStage:
             "pattern": self.pattern.to_dict(),
             "strategy": self.strategy.to_dict(),
             "alignment": self.alignment.to_dict(),
-            "imaging": self.imaging.to_dict()
+            "imaging": self.imaging.to_dict(),
         }
 
     @classmethod
@@ -123,7 +131,7 @@ class FibsemMillingStage:
             pattern=get_pattern(pattern_name, data["pattern"]),
             strategy=get_strategy(strategy_name, config=strategy_config),
             alignment=MillingAlignment.from_dict(alignment),
-            imaging=ImageSettings.from_dict(imaging)
+            imaging=ImageSettings.from_dict(imaging),
         )
 
     @property

--- a/fibsem/milling/core.py
+++ b/fibsem/milling/core.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from pathlib import Path
 from typing import List, Tuple
 
 from fibsem import config as fcfg
@@ -23,7 +24,6 @@ from fibsem.utils import current_timestamp_v2
 def setup_milling(
     microscope: FibsemMicroscope,
     milling_stage: FibsemMillingStage,
-    ref_image: FibsemImage = None,
 ):
     """Setup Microscope for FIB Milling.
 
@@ -33,17 +33,10 @@ def setup_milling(
     """
 
     # acquire reference image for drift correction
-    if milling_stage.alignment.enabled and ref_image is None:
-        image_settings = ImageSettings(
-            hfw=milling_stage.milling.hfw,
-            dwell_time=1e-6,
-            resolution=[1536, 1024],
-            beam_type=milling_stage.milling.milling_channel,
-            reduced_area=milling_stage.alignment.rect,
-            path=fcfg.DATA_CC_PATH, # TODO: set this to the last-path?
-            filename=f"ref_{milling_stage.name}_initial_alignment_{current_timestamp_v2()}"
+    if milling_stage.alignment.enabled:
+        reference_image = get_stage_reference_image(
+            microscope=microscope, milling_stage=milling_stage
         )
-        ref_image = microscope.acquire_image(image_settings)
 
     # set up milling settings
     microscope.setup_milling(mill_settings=milling_stage.milling)
@@ -52,10 +45,14 @@ def setup_milling(
     if milling_stage.alignment.enabled:
         from fibsem import alignment
         logging.info(f"FIB Aligning at Milling Current: {milling_stage.milling.milling_current:.2e}")
-        alignment.multi_step_alignment_v2(microscope=microscope, 
-                                        ref_image=ref_image, 
-                                        beam_type=milling_stage.milling.milling_channel, 
-                                        steps=3, use_autocontrast=True)  # high current -> damaging
+        alignment.multi_step_alignment_v2(
+            microscope=microscope,
+            ref_image=reference_image,
+            beam_type=milling_stage.milling.milling_channel,
+            steps=3,
+            use_autocontrast=True,
+        )  # high current -> damaging
+
 
 # TODO: migrate run milling to take milling_stage argument, rather than current, voltage
 def run_milling(
@@ -165,19 +162,10 @@ def mill_stages(
                     logging.info(ddict)
             microscope.milling_progress_signal.connect(_handle_progress)
 
-
-        # TODO: move into try, only do for stage ===0
-        image_settings = ImageSettings(
-            hfw=stages[0].milling.hfw,
-            dwell_time=1e-6,
-            resolution=[1536, 1024],
-            beam_type=stages[0].milling.milling_channel,
-            reduced_area=stages[0].alignment.rect,
-            path=fcfg.DATA_CC_PATH, # TODO: set this to the last-path?
-            filename=f"ref_{stages[0].name}_initial_alignment_{current_timestamp_v2()}"
+        reference_image = get_stage_reference_image(
+            microscope=microscope, milling_stage=stages[0]
         )
-        ref_image = microscope.acquire_image(image_settings)
-        
+
         initial_beam_shift = microscope.get("shift", beam_type=stages[0].milling.milling_channel)
 
         # TODO: reset beam shift after aligning at milling current
@@ -197,7 +185,7 @@ def mill_stages(
                 parent_ui.milling_progress_signal.emit(msgd)
 
             try:
-                stage.ref_image = ref_image
+                stage.reference_image = reference_image
                 stage.strategy.run(
                     microscope=microscope,
                     stage=stage,
@@ -281,5 +269,29 @@ def acquire_images_after_milling(
 
     return images
 
-# QUERY: should List[FibsemMillingStage] be a class? that has it's own settings? 
+
+def get_stage_reference_image(
+    microscope: FibsemMicroscope, milling_stage: FibsemMillingStage
+) -> FibsemImage:
+    ref_image = milling_stage.reference_image
+    if isinstance(ref_image, FibsemImage):
+        return ref_image
+    elif ref_image is None:
+        path = milling_stage.imaging.path
+        if path is None:
+            path = Path(fcfg.DATA_CC_PATH)
+        image_settings = ImageSettings(
+            hfw=milling_stage.milling.hfw,
+            dwell_time=1e-6,
+            resolution=[1536, 1024],
+            beam_type=milling_stage.milling.milling_channel,
+            reduced_area=milling_stage.alignment.rect,
+            path=path,
+            filename=f"ref_{milling_stage.name}_initial_alignment_{current_timestamp_v2()}",
+        )
+        return microscope.acquire_image(image_settings)
+    raise TypeError(f"Invalid ref_image type '{type(ref_image)}'")
+
+
+# QUERY: should List[FibsemMillingStage] be a class? that has it's own settings?
 # E.G. should acquire images be set at that level, rather than at the stage level?

--- a/fibsem/milling/core.py
+++ b/fibsem/milling/core.py
@@ -3,7 +3,7 @@ import time
 from pathlib import Path
 from typing import List, Tuple
 
-from fibsem import config as fcfg
+from fibsem import acquire, config as fcfg
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling import FibsemMillingStage
 from fibsem.structures import (
@@ -286,10 +286,11 @@ def get_stage_reference_image(
             resolution=[1536, 1024],
             beam_type=milling_stage.milling.milling_channel,
             reduced_area=milling_stage.alignment.rect,
+            save=True,
             path=path,
             filename=f"ref_{milling_stage.name}_initial_alignment_{current_timestamp_v2()}",
         )
-        return microscope.acquire_image(image_settings)
+        return acquire.acquire_image(microscope, image_settings)
     raise TypeError(f"Invalid ref_image type '{type(ref_image)}'")
 
 

--- a/fibsem/milling/strategy/standard.py
+++ b/fibsem/milling/strategy/standard.py
@@ -29,7 +29,7 @@ class StandardMillingStrategy(MillingStrategy[StandardMillingConfig]):
         parent_ui = None,
     ) -> None:
         logging.info(f"Running {self.name} Milling Strategy for {stage.name}")
-        setup_milling(microscope, milling_stage=stage, ref_image=stage.ref_image)
+        setup_milling(microscope, milling_stage=stage)
 
         draw_patterns(microscope, stage.pattern.define())
 

--- a/tests/milling/test_core.py
+++ b/tests/milling/test_core.py
@@ -1,0 +1,36 @@
+import os
+import glob
+from pathlib import Path
+
+from fibsem import utils
+from fibsem.milling import FibsemMillingStage, mill_stages
+
+
+def test_mill_stages_with_acquisitions(tmp_path: Path) -> None:
+    """Test milling stages with image acquisitions (alignment, reference images, etc.).
+    Smoke test to ensure images are being acquired and saved correctly.
+    """
+    # setup a microscope session
+    microscope, settings = utils.setup_session(manufacturer="Demo")
+
+    milling_stage = FibsemMillingStage(name="test-stage")
+    milling_stage.milling.acquire_images = True
+    milling_stage.alignment.enabled = True
+    milling_stage.imaging.path = tmp_path
+    milling_stage.imaging.save = True
+    mill_stages(microscope, [milling_stage])
+
+    # check for the expected reference image
+    glob_pattern = f"ref_{milling_stage.name}_initial_alignment*.tif"
+    files = glob.glob(os.path.join(tmp_path, glob_pattern))
+    assert len(files) > 0, f"No files found in {tmp_path} with pattern {glob_pattern}"
+
+    # check for the beam shift alignment files
+    glob_pattern = "beam_shift_alignment*.tif"
+    files = glob.glob(os.path.join(tmp_path, glob_pattern))
+    assert len(files) > 0, f"No files found in {tmp_path} with pattern {glob_pattern}"
+
+    # check for the post acquisition reference image
+    glob_pattern = f"ref_milling_{milling_stage.name}_finished_*.tif"
+    files = glob.glob(os.path.join(tmp_path, glob_pattern))
+    assert len(files) == 2, f"No files found in {tmp_path} with pattern {glob_pattern}"


### PR DESCRIPTION
Currently `stage.ref_image = ref_image` is set in `mill_stages` but `FibsemMillingStage` doesn't have a proper attribute for it, so this is a potential way of handling it more formally.

The complicating factor was the `to_dict` conversion. I have handled this by allowing `reference_image` to be `ImageSettings`, as that allows for the reference image to be retaken with the same settings. I'm not sure if that's the best way though. Another option I considered is saving the reference image and using the path, which would mean alignment could persist even if an experiment is reloaded. However, that would mean a change would be required around the saving of reference images, so I thought I'd propose this solution and see what you think.

I've also refactored out `get_stage_reference_image` to avoid code duplication between `setup_milling` and `mill_stages`.